### PR TITLE
[22.11.29, 정재혁] (Add ,Mod) 시작화면 리사이즈 기능 추가, pvp 최소 화면 + 리사이즈 설정 완료

### DIFF
--- a/src/game.py
+++ b/src/game.py
@@ -86,6 +86,9 @@ def intro_screen():
                         # option button
                         if r_btn_option_rect.collidepoint(x, y):
                             option()
+                # intro 화면 resize관련 부분 추가
+                if event.type == pygame.VIDEORESIZE:
+                    check_scr_size(event.w, event.h)
 
         # interface draw
         if pygame.display.get_surface() is not None:

--- a/src/pvp.py
+++ b/src/pvp.py
@@ -180,7 +180,7 @@ def pvp():
                             jumpingx2_2p = False
                     if event.type == pygame.VIDEORESIZE:
                         # check_scr_size(event.w, event.h)
-                        pvp_scr_size(event.w,event.h)
+                        pvp_check_scr_size(event.w,event.h)
 
             if not paused:
                 if go_left_1p:
@@ -401,7 +401,7 @@ def pvp():
 
                     if event.type == pygame.VIDEORESIZE:
                         # check_scr_size(event.w, event.h)
-                        pvp_scr_size(event.w,event.h)
+                        check_(event.w,event.h)
                 r_btn_restart_rect.centerx, r_btn_restart_rect.centery = resized_screen.get_width() * 0.35, resized_screen.get_height() * 0.55
                 r_btn_exit_rect.centerx, r_btn_exit_rect.centery = resized_screen.get_width() * 0.65, resized_screen.get_height() * 0.55
                 disp_pvp_gameover_buttons(btn_restart, btn_exit)

--- a/src/setting.py
+++ b/src/setting.py
@@ -16,6 +16,8 @@ pygame.init()
 display.set_caption("RunningPVP-T-rex by_Let`sGitIt")
 gamer_name = ''
 scr_size = (width, height) = (800, 400)
+# 최소 화면 설정
+pvp_scr_size = (pvp_width, pvp_height) = (1200, 400)
 FPS = 60
 gravity = 0.65
 
@@ -277,9 +279,14 @@ def check_scr_size(eventw, eventh):
             adjusted_height = int(eventw / (width / height))
             resized_screen = display.set_mode((eventw, adjusted_height), RESIZABLE)
 
-def pvp_scr_size(eventw, eventh):
-    adjusted_height = int(eventw / 3)
-    resized_screen = display.set_mode((eventw, adjusted_height), RESIZABLE)
+def pvp_check_scr_size(eventw, eventh):
+    if (eventw < pvp_width and eventh < pvp_height) or (eventw < pvp_width) or (eventh < pvp_height):
+        # 최소해상도
+        resized_screen = display.set_mode((pvp_scr_size), RESIZABLE)
+    else:
+        if (eventw / eventh) != (width / height):
+            adjusted_height = int(eventw / (pvp_width/pvp_height))
+            resized_screen = display.set_mode((eventw, adjusted_height), RESIZABLE)
 
 def full_screen_issue():
     global scr_size


### PR DESCRIPTION
인트로 화면 리사이즈 배율에 따라 가능하도록 수정했고, pvp 모드 최소화면 지정해두고 최소 화면 사이즈는 1200:400으로 지정해 뒀습니다. 전체 화면 하면 화면 스크린 사이즈에 맞게 배율 바껴요..!