### PR TITLE
[22/12.4, 김재홍] (Mod) pvp 러닝모드 win,lose 표기 변경

### DIFF
--- a/src/pvprunning.py
+++ b/src/pvprunning.py
@@ -898,8 +898,6 @@ def pvprunning():
                             game_quit = True
 
                     if event.type == pygame.MOUSEBUTTONDOWN:
-                        # game_over = False
-                        # game_quit = True
                         if pygame.mouse.get_pressed() == (1, 0, 0):
                             x, y = event.pos
                             if r_btn_restart_rect.collidepoint(x, y):
@@ -913,7 +911,7 @@ def pvprunning():
                 r_btn_restart_rect.centerx, r_btn_restart_rect.centery = resized_screen.get_width() * 0.35, resized_screen.get_height() * 0.55
                 r_btn_exit_rect.centerx, r_btn_exit_rect.centery = resized_screen.get_width() * 0.65, resized_screen.get_height() * 0.55
                 disp_pvp_gameover_buttons(btn_restart, btn_exit)
-                disp_pvp_winner_loser(player1_dino)
+                disp_pvp_r_winner_loser(player1_dino)
 
                 resized_screen.blit(
                     pygame.transform.scale(screen, (resized_screen.get_width(), resized_screen.get_height())),

--- a/src/setting.py
+++ b/src/setting.py
@@ -10,7 +10,6 @@ from pygame import time
 from pygame import transform
 from pygame.locals import RESIZABLE, RLEACCEL
 
-
 mixer.pre_init(44100, -16, 2, 2048)
 pygame.init()
 display.set_caption("RunningPVP-T-rex by_Let`sGitIt")
@@ -201,8 +200,8 @@ def disp_pvp_gameover_buttons(btn_restart, btn_exit):
     btn_exit_rect = btn_exit.get_rect()
     btn_restart_rect.centerx = width * 0.35
     btn_exit_rect.centerx = width * 0.65
-    btn_restart_rect.centery = height * 0.55
-    btn_exit_rect.centery = height * 0.55
+    btn_restart_rect.centery = height * 0.5
+    btn_exit_rect.centery = height * 0.5
     screen.blit(btn_restart, btn_restart_rect)
     screen.blit(btn_exit, btn_exit_rect)
 
@@ -217,8 +216,21 @@ def disp_pvp_winner_loser(player1):
         win_width = width * 0.70
         lose_width = width * 0.17
 
-    screen.blit(win, (win_width, height * 0.2))
-    screen.blit(lose, (lose_width, height * 0.2))
+    screen.blit(win, (win_width, height * 0.15))
+    screen.blit(lose, (lose_width, height * 0.15))
+
+def disp_pvp_r_winner_loser(player1):
+    win = large_font.render("WIN", True, black)
+    lose = large_font.render("LOSE", True, black)
+    if not player1.is_dead:
+        win_height = height * 0.6
+        lose_height = height * 0.1
+    else:
+        win_height = height * 0.1
+        lose_height = height * 0.6
+
+    screen.blit( win, ((width * 0.43) , win_height ))
+    screen.blit( lose, ((width * 0.415) , lose_height ))
 
 
 def disp_intro_buttons(btn_gamestart, btn_board, btn_store, btn_option):


### PR DESCRIPTION
![러닝모드 win_lose](https://user-images.githubusercontent.com/108072455/205475787-8f711fbc-e088-4ae3-a23d-a79e9c3e7afa.png)

러닝모드 승/패 표시 방식 업데이트
![러닝모드 win_lose 함수](https://user-images.githubusercontent.com/108072455/205475795-15ec5803-3e11-4141-a8b1-2817b1b3be43.png)
